### PR TITLE
Add type to filter option

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -18,5 +18,9 @@
   "selectDescriptionAfterUrl": {
     "message": "Which container would you prefer",
     "description": "Description of select container; After the url"
+  },
+  "contextPrefixMessage": {
+    "message": "Containers matching prefix:",
+    "description": "Message to show if user is typing to search for a context"
   }
 }

--- a/_locales/zh-CN/messages.json
+++ b/_locales/zh-CN/messages.json
@@ -13,5 +13,8 @@
   },
   "selectDescriptionAfterUrl": {
     "message": "您希望使用哪个容器打开这个网页"
+  },
+  "contextPrefixMessage": {
+    "message": "匹配前缀的容器"
   }
 }

--- a/togo/index.html
+++ b/togo/index.html
@@ -17,6 +17,10 @@
       <p><span data-i18n="selectDescriptionBeforeUrl"></span></p>
       <div id="redirect-url"></div>
       <p><span data-i18n="selectDescriptionAfterUrl"></span></p>
+      <p id="context-prefix-message">
+        <span data-i18n="contextPrefixMessage"></span>
+        <span id="context-prefix"></span>
+      </p>
       <br />
       <ul class="button-container" id="container-list"></ul>
     </form>

--- a/togo/togo.css
+++ b/togo/togo.css
@@ -1,4 +1,3 @@
-
 #redirect-url,
 #redirect-origin {
   font-weight: bold;
@@ -15,6 +14,10 @@
   padding-block-start: 0.5rem;
   padding-inline-end: 0.5rem;
   padding-inline-start: 0.5rem;
+}
+
+#context-prefix-message {
+  visibility: hidden;
 }
 
 #container-list {
@@ -37,4 +40,3 @@
   height: 16px;
   margin: -1px;
 }
-

--- a/togo/togo.js
+++ b/togo/togo.js
@@ -28,8 +28,8 @@
 
   // given a cookieStoreId (reference to a container), create a new tab with
   // the URL, switch to it and close the temporary tab.
-  function createTabAndSwitchTab(cookieStoreId) {
-    const current = browser.tabs.getCurrent();
+  async function createTabAndSwitchTab(cookieStoreId) {
+    const current = await browser.tabs.getCurrent();
     const { active, index, windowId } = current;
     browser.tabs.create({
       url: url + '',


### PR DESCRIPTION
Hello tiansh! :wave: 

Thanks for creating this addon, I find it to be very helpful.

This PR adds a new feature which allows users to type to select containers on the new tab page. It looks a little like this in action:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1774239/93276776-6d6b1980-f7b8-11ea-8b9f-38c5ff596bc5.gif)

If the typed prefix matches a single container, that container is immediately used to open the new tab. In the clip, none of my containers start with `x`, however only one starts with `p` so as soon as I press that key the addon opens the URL in that container.

I hope `匹配前缀的容器` means what I think it does!
