### PR TITLE
Fix to handle new location of aboutNetError.css in FF 107 and newer.

### DIFF
--- a/togo/index.html
+++ b/togo/index.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8" />
   <title></title>
   <link xmlns="http://www.w3.org/1999/xhtml" rel="stylesheet" href="chrome://browser/skin/aboutNetError.css" type="text/css" media="all">
+  <link xmlns="http://www.w3.org/1999/xhtml" rel="stylesheet" href="chrome://global/skin/aboutNetError.css" type="text/css" media="all">
   <link rel="stylesheet" href="togo.css">
 </head>
 


### PR DESCRIPTION
Since FF 107 (or so) the location of `chrome://browser/skin/aboutNetError.css` has been changed to `chrome://global/skin/aboutNetError.css`. This PR adds both links to `index.html` to ensure that "Open this page in container..." message is styled correctly.